### PR TITLE
Feat/category

### DIFF
--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Global, Module, forwardRef } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
 import { EventsModule } from 'src/events/events.module';
@@ -13,9 +13,10 @@ import { MemberModule } from 'src/member/member.module';
 @Module({
   imports: [
     TypeOrmModule.forFeature([ChatRoom, ChatContent, User, Plan]),
-    PassportModule, EventsModule, MemberModule
+    PassportModule, MemberModule
   ],
   controllers: [ChatController],
   providers: [ChatService],
+  exports: [ChatService]
 })
 export class ChatModule { }

--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -9,10 +9,11 @@ import { ChatContent } from './entities/chat_contents.entity';
 import { User } from 'src/user/entities/user.entity';
 import { Plan } from 'src/plan/entities/plan.entity';
 import { MemberModule } from 'src/member/member.module';
+import { Member } from 'src/member/entities/member.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ChatRoom, ChatContent, User, Plan]),
+    TypeOrmModule.forFeature([ChatRoom, ChatContent, User, Plan, Member]),
     PassportModule, MemberModule
   ],
   controllers: [ChatController],

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -7,6 +7,7 @@ import { EventsGateway } from 'src/events/events.gateway';
 import { User } from 'src/user/entities/user.entity';
 import { Plan } from 'src/plan/entities/plan.entity';
 import _ from 'lodash';
+import { Member } from 'src/member/entities/member.entity';
 
 @Injectable()
 export class ChatService {
@@ -15,6 +16,7 @@ export class ChatService {
     @InjectRepository(ChatContent) private readonly chatcontentRepository: Repository<ChatContent>,
     @InjectRepository(User) private readonly userRepository: Repository<User>,
     @InjectRepository(Plan) private readonly planRepository: Repository<Plan>,
+    @InjectRepository(Member) private readonly memberRepository: Repository<Member>
   ) { }
 
   //채팅방 만들기
@@ -79,15 +81,16 @@ export class ChatService {
 
   //유저가 속한 플랜과 채팅방 조회
   async getPlanNChat(userId: number) {
-    const plans = await this.planRepository.find({ where: { userId } });
+    const plans = await this.memberRepository.find({ where: { userId } });
     let planchat = [];
 
     for (let i = 0; i < plans.length; i++) {
-      const room = await this.chatroomRepository.findOneBy({ planId: plans[i].id });
+      const plan = await this.planRepository.findOneBy({ id: plans[i].planId });
+      const room = await this.chatroomRepository.findOneBy({ planId: plans[i].planId });
       if (!room) {
-        console.log(`${plans[i].id} 플랜의 채팅방이 존재하지 않습니다.`);
+        console.log(`${plans[i].planId} 플랜의 채팅방이 존재하지 않습니다.`);
       }
-      const pr = { "plan": plans[i], "room": room };
+      const pr = { "plan": plan, "room": room };
       planchat.push({ "PlanRoom": pr });
     }
 

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -15,8 +15,6 @@ export class ChatService {
     @InjectRepository(ChatContent) private readonly chatcontentRepository: Repository<ChatContent>,
     @InjectRepository(User) private readonly userRepository: Repository<User>,
     @InjectRepository(Plan) private readonly planRepository: Repository<Plan>,
-
-    private eventGateway: EventsGateway
   ) { }
 
   //채팅방 만들기
@@ -35,7 +33,6 @@ export class ChatService {
     await this.chatroomRepository.save({ planId, name: roomName });
     const room = await this.chatroomRepository.findOne({ where: { planId } });
 
-    this.eventGateway.createRoom(room);
     return room;
   }
 
@@ -50,8 +47,6 @@ export class ChatService {
 
     const message = await this.chatcontentRepository.save({ roomId, userId, chat })
 
-    //message return 전에 gateway로 보내기
-    this.eventGateway.sendMessage(message);
     return { name: user.nickname, ...message };
   }
 

--- a/src/events/events.gateway.ts
+++ b/src/events/events.gateway.ts
@@ -1,6 +1,7 @@
 import { SubscribeMessage, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
-
+import * as jwt from 'jsonwebtoken';
 import { Server } from 'socket.io';
+import { Socket } from 'socket.io';
 import { ServerToClientEvents } from './types/events';
 import { ChatContent } from 'src/chat/entities/chat_contents.entity';
 import { ChatRoom } from 'src/chat/entities/chat_rooms.entity';
@@ -10,41 +11,138 @@ import { OnModuleInit, UseGuards } from '@nestjs/common';
 import { Member } from 'src/member/entities/member.entity';
 import { AuthGuard } from '@nestjs/passport';
 import { MemberGuard } from 'src/utils/member.guard';
+import { ChatService } from 'src/chat/chat.service';
+import { User } from 'src/user/entities/user.entity';
+import * as dotenv from 'dotenv';
 
-@UseGuards(AuthGuard('jwt'))
-//@UseGuards(MemberGuard)
-@WebSocketGateway(3001, { namespace: 'events', cors: '*' })
+// 환경 변수 로드
+dotenv.config();
+
+// 소켓 타입 확장
+interface CustomSocket extends Socket {
+    authorization?: string;
+    userId?: number;
+    roomId?: number;
+}
+
+// @UseGuards(MemberGuard)
+@WebSocketGateway({ namespace: 'events', cors: { origin: 'http://localhost:3001', credentials: true } })
 export class EventsGateway implements OnModuleInit {
     constructor(
+        private readonly chatService: ChatService,
         @InjectRepository(ChatContent)
         private readonly chatContentRepository: Repository<ChatContent>,
         @InjectRepository(ChatRoom)
         private readonly chatRoomRepository: Repository<ChatRoom>,
+        @InjectRepository(Member)
+        private readonly memberRepository: Repository<Member>,
+        @InjectRepository(User)
+        private readonly userRepository: Repository<User>,
     ) { }
 
     @WebSocketServer()
-    server: Server<any, ServerToClientEvents>;
+    server: Server<CustomSocket, ServerToClientEvents>;
 
     onModuleInit() {
-        this.server.on('connection', (socket) => {
+        this.server.on('connection', (socket: CustomSocket) => {
 
-            // 클라이언트가 WebSocket으로 연결될 때 실행되는 로직
-            const headers = socket.handshake.headers; // 클라이언트에서 보낸 헤더 정보
-            console.log('Headers:', headers);
+            const authorization = socket.handshake.headers['authorization'] as string; // 'Authorization' 헤더
+            console.log('Authorization:', authorization);
 
-            console.log(socket.id);
-            console.log('Connected');
-            this.server.emit('connected');
+            // 다른 곳에서 사용할 수 있도록 저장
+            socket.authorization = authorization;
+
+            if (!authorization) {
+                // 권한 부여 헤더가 없을 때 처리
+                console.log('No Authorization header');
+                socket.disconnect();
+                return;
+            }
+
+            try {
+                // JWT 토큰을 검증
+                const token = authorization.replace('Bearer ', '');
+                const decoded = jwt.verify(token, process.env.JWT_ACCESS_TOKEN_SECRET) as { [key: string]: any };; // JWT 시크릿 키
+
+
+                console.log("decoded : ", decoded);
+                const userId = parseInt(decoded['sub'], 10);
+                // 토큰에서 유저 정보 추출
+                // const userId = decoded['sub']; // 예: 토큰에 userId가 있음
+                console.log('User ID:', userId);
+
+                if (isNaN(userId)) {
+                    console.log('Invalid userId');
+                    socket.disconnect();
+                    return;
+                }
+
+                // 사용자 ID를 소켓에 연결
+                socket.userId = userId;
+
+                console.log('Socket ID:', socket.id);
+                console.log('Connected');
+
+                this.server.emit('connected');
+            } catch (error) {
+                console.log('Invalid JWT:', error);
+                socket.disconnect(); // 토큰이 유효하지 않을 경우 소켓 연결 끊기
+            }
         });
     }
 
+    //@UseGuards(AuthGuard('jwt'))
+    //@UseGuards(MemberGuard)
     @SubscribeMessage('message')
-    handleMessage(client: any, payload: any): void {
-        console.log("client : ", client);
-        console.log("payload : ", payload);
+    async handleMessage(client: CustomSocket, payload: { roomId: number, chat: string }) {
 
-        const responseMessage = payload;
-        this.server.emit('responseMessage', responseMessage);
+        console.log("client userId:", client.userId);
+        console.log("authorization:", client.authorization);
+
+        // roomId를 소켓에 저장
+        client.roomId = payload.roomId;
+
+        console.log("현재 roomId :", client.roomId);
+
+        const chat = await this.chatService.createMessage(payload.roomId, client.userId, payload.chat);
+        const user = await this.userRepository.findOneBy({ id: client.userId });
+
+        const responseMessage = { "name": user.nickname, "chat": payload.chat };
+
+        // 특정 방에만 메시지 전송
+        this.server.to(`room-${payload.roomId}`).emit('responseMessage', responseMessage);
+    }
+
+    //채팅방 입장
+    //해당 플랜/채팅방에 초대된 멤버인지 검증 후 추가
+    @SubscribeMessage('joinRoom')
+    async handleJoinRoom(client: CustomSocket, payload: { roomId: number }) {
+        const roomId = payload.roomId;
+
+        console.log("joinRoom payload : ", payload);
+        console.log("joinRoom roomId : ", roomId);
+
+        const plan = await this.chatRoomRepository.findOneBy({ roomId });
+
+        console.log("joinRoom 해당 플랜 찾음 : ", plan);
+        console.log("joinRoom planId : ", plan.planId);
+
+        // 방에 참여할 수 있는지 확인
+        const member = await this.memberRepository.findOne({
+            where: { userId: client.userId, planId: plan.planId },
+        });
+
+        console.log("joinRoom member : ", member);
+
+        if (member) {
+            client.join(`room-${roomId}`); // 클라이언트를 해당 방에 추가
+            client.emit('joinRoomSuccess');
+            console.log(`UserId : ${client.userId} ,roomId : ${roomId} 들어옴`);
+            this.server.to(`room-${roomId}`).emit('memberJoined', { userId: client.userId });
+        } else {
+            console.log(`UserId : ${client.userId}가 roomId : ${roomId}에 초대되어 있지 않습니다.`);
+            client.emit('joinRoomFailed', { message: '해당 채팅방에 초대된 멤버가 아닙니다.' });
+        }
     }
 
     createRoom(room: ChatRoom) {
@@ -60,5 +158,5 @@ export class EventsGateway implements OnModuleInit {
         this.server.emit('addMember', member);
 
     }
-}
 
+}

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,12 +1,19 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { EventsGateway } from './events.gateway';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ChatContent } from 'src/chat/entities/chat_contents.entity';
 import { ChatRoom } from 'src/chat/entities/chat_rooms.entity';
+import { Member } from 'src/member/entities/member.entity';
+import { User } from 'src/user/entities/user.entity';
+import { Plan } from 'src/plan/entities/plan.entity';
+import { ChatService } from 'src/chat/chat.service';
+import { ChatModule } from 'src/chat/chat.module';
 
 @Module({
     imports: [
-        TypeOrmModule.forFeature([ChatRoom, ChatContent])
+        TypeOrmModule.forFeature([ChatRoom, ChatContent, Member, User, Plan]),
+        // forwardRef(() => ChatModule)
+        ChatModule
     ],
     providers: [EventsGateway],
     exports: [EventsGateway],

--- a/src/events/types/events.ts
+++ b/src/events/types/events.ts
@@ -10,4 +10,5 @@ export interface ServerToClientEvents {
     connected: () => void;
     responseMessage: (payload: { name: string; chat: string }) => void;
     memberJoined: (payload: { userId: number }) => void;
+    typing: (payload: { nickname: string, isTyping: boolean }) => void;
 }

--- a/src/events/types/events.ts
+++ b/src/events/types/events.ts
@@ -8,5 +8,6 @@ export interface ServerToClientEvents {
     addMember: (payload: Member) => void;
     //단순히 서버와 클라이언트 연결 상태 나타내려는 것이므로 매개 변수 필요 없음
     connected: () => void;
-    responseMessage: (message: string) => string;
+    responseMessage: (payload: { name: string; chat: string }) => void;
+    memberJoined: (payload: { userId: number }) => void;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ async function bootstrap() {
   app.use(cookieParser());
 
   app.enableCors({
-    origin: "http://localhost:3002",
+    origin: "http://localhost:3001",
     methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
     preflightContinue: false,
     optionsSuccessStatus: 204,

--- a/src/member/dto/create-member.dto.ts
+++ b/src/member/dto/create-member.dto.ts
@@ -1,7 +1,7 @@
-import { IsNotEmpty, IsNumber } from "class-validator";
+import { IsNotEmpty, IsString } from "class-validator";
 
 export class CreateMemberDto {
-    @IsNumber()
-    @IsNotEmpty({ message: '해당 플랜에 초대할 멤버(userId값)를 입력해주세요.' })
-    userId: number;
+    @IsString()
+    @IsNotEmpty({ message: '해당 플랜에 초대할 멤버의 닉네임을 입력해주세요.' })
+    nickname: string;
 }

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -21,7 +21,7 @@ export class MemberController {
   @Post('plan/:planId')
   @ApiOperation({ summary: '멤버 추가 API', description: '플랜에 멤버를 추가한다.' })
   async create(@Param('planId') planId: number, @Body() createMemberDto: CreateMemberDto) {
-    const member = await this.memberService.create(planId, createMemberDto.userId);
+    const member = await this.memberService.create(planId, createMemberDto.nickname);
 
     return {
       statusCode: HttpStatus.OK,

--- a/src/member/member.module.ts
+++ b/src/member/member.module.ts
@@ -1,4 +1,4 @@
-import { Global, Module } from '@nestjs/common';
+import { Global, Module, forwardRef } from '@nestjs/common';
 import { MemberService } from './member.service';
 import { MemberController } from './member.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -12,7 +12,7 @@ import { EventsModule } from 'src/events/events.module';
 @Module({
   imports: [
     TypeOrmModule.forFeature([Member, Plan, User]),
-    PassportModule, EventsModule
+    PassportModule,
   ],
   controllers: [MemberController],
   providers: [MemberService],

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -40,22 +40,8 @@ export class MemberService {
 
     this.eventGateway.addMember(member);
 
-    return member;
+    return { ...member, "nickname": user.nickname };
   }
-
-  // async findAll(planId: number) {
-  //   const members = await this.memberRepository.find({
-  //     where: { planId },
-  //     relations: ['user'],
-  //     select: {
-  //       user: {
-  //         nickname: true
-  //       }
-  //     }
-  //   });
-
-  //   return members;
-  // }
 
   async findAll(planId: number) {
     const members = await this.memberRepository.find({
@@ -103,6 +89,10 @@ export class MemberService {
     const member = await this.memberRepository.findOne({
       where: { memberId },
     });
+
+    if (member.type === 'Leader') {
+      throw new BadRequestException("플랜의 리더는 삭제할 수 없습니다.");
+    }
 
     const user = await this.userRepository.findOneBy({ id: member.userId });
 

--- a/src/plan/plan.module.ts
+++ b/src/plan/plan.module.ts
@@ -53,4 +53,4 @@ import { PlanComment } from 'src/plan-comment/entities/plan-comment.entity';
   ],
   exports: [PlanService],
 })
-export class PlanModule {}
+export class PlanModule { }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -39,7 +39,7 @@ export class User {
   @Column({ type: 'varchar', unique: false, nullable: false })
   name: string;
 
-  @Column({ type: 'varchar', unique: false, nullable: false })
+  @Column({ type: 'varchar', unique: true, nullable: false })
   nickname: string;
 
   @Column({ type: 'varchar', unique: false, nullable: false })

--- a/src/utils/member.guard.ts
+++ b/src/utils/member.guard.ts
@@ -37,7 +37,7 @@ export class MemberGuard extends JwtAuthGuard implements CanActivate {
 
         console.log('member-guard: userId, planId', userId, planId);
 
-        console.log("memberService : ", this.memberService);
+        //console.log("memberService : ", this.memberService);
 
         const member = await this.memberService.findMember(userId, planId);
 


### PR DESCRIPTION
내 채팅방과 플랜 조회 시 리더 타입만 조회가 가능해서 멤버들도 조회 가능하도록 수정, 
 멤버 추가할 때 멤버 id가 아닌 닉네임으로 추가 (유저 엔티티 닉네임 속성 unique추가),
 채팅방 소켓을 원래 3001로 연결했었는데 3000으로 변경하면서 프론트가 3002가 아닌 3001로 연결됨 => main.ts cors 3001로 변경,
채팅방 연결(타이핑 중인 사용자 알려줌, 채팅방에 입장한 멤버 알려줌)

