### PR TITLE
fix: jpg UUID 불일치 문제 수정

### DIFF
--- a/src/aws/aws.service.ts
+++ b/src/aws/aws.service.ts
@@ -29,7 +29,7 @@ export class AwsService {
     // AWS S3에 이미지 업로드 명령을 생성합니다. 파일 이름, 파일 버퍼, 파일 접근 권한, 파일 타입 등을 설정합니다.
     const command = new PutObjectCommand({
       Bucket: this.configService.get('AWS_S3_BUCKET_NAME'), // S3 버킷 이름
-      Key: fileName, // 업로드될 파일의 이름
+      Key: `${fileName}`, // 업로드될 파일의 이름
       Body: file.buffer, // 업로드할 파일
       ACL: 'public-read', // 파일 접근 권한
       ContentType: `image/${ext}`, // 파일 타입
@@ -39,7 +39,7 @@ export class AwsService {
     await this.s3Client.send(command);
 
     // 업로드된 이미지의 URL을 반환합니다.
-    return `https://s3.${process.env.AWS_REGION}.amazonaws.com/${process.env.AWS_S3_BUCKET_NAME}/${fileName}`;
+    return `https://s3.${process.env.AWS_REGION}.amazonaws.com/${process.env.AWS_S3_BUCKET_NAME}/${fileName}.${ext}`;
   }
 
   async deleteUploadToS3(fileName: string) {

--- a/src/plan/plan.service.ts
+++ b/src/plan/plan.service.ts
@@ -21,6 +21,7 @@ import { PlanType } from './types/plan.type';
 import { Category } from 'src/category/entities/category.entity';
 import { Area } from 'src/location/entities/area.entity';
 import { Favorite } from './entities/favorite.entity';
+import { join } from 'path';
 
 @Injectable()
 export class PlanService {
@@ -134,7 +135,7 @@ export class PlanService {
     }
 
     const imageName = this.utilsService.getUUID();
-    const ext = file ? file.originalname.split('.').pop() : 'png';
+    const ext = join(file.originalname).split('.').pop()
 
     if (ext) {
       imageUrl = await this.awsService.imageUploadToS3(
@@ -273,7 +274,7 @@ export class PlanService {
     }
 
     const imageName = this.utilsService.getUUID();
-    const ext = file ? file.originalname.split('.').pop() : 'png';
+    const ext = join(file.originalname).split('.').pop()
 
     if (ext) {
       imageUrl = await this.awsService.imageUploadToS3(

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -17,6 +17,7 @@ import { MailerService } from 'src/mailer/mailer.service';
 import { AwsService } from 'src/aws/aws.service';
 import { RedisService } from 'src/redis/redis.service';
 import { Location } from '../location/entities/location.entity';
+import { join } from 'path';
 
 
 @Injectable()
@@ -110,7 +111,7 @@ export class UserService {
 
     //S3에 이미지 업로드, url return
     const imageName = this.utilsService.getUUID();
-    const ext = file ? file.originalname.split('.').pop() : 'png';
+    const ext = join(file.originalname).split('.').pop()
 
     if (ext) {
       imageUrl = await this.awsService.imageUploadToS3(


### PR DESCRIPTION
S3를 확인해보니 jpg가 저장은 업로드는 되는데, 페이지에서 보이지 않는 사진의 url과 UUID가 일치하지 않아 불일치하는 것을 확인했습니다. 그래서 aws 설정에서 ext를 포함시켜주고 그것으로 UUID를 생성하는 방식으로 수정했습니다.